### PR TITLE
docs: add CI/CD workflow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A modern and robust C# Technical Analysis library based on the original open-sou
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/phmatray/TaLibStandard)](https://github.com/phmatray/TaLibStandard/pulls)
 [![GitHub contributors](https://img.shields.io/github/contributors/phmatray/TaLibStandard)](https://github.com/phmatray/TaLibStandard/graphs/contributors)
 [![GitHub last commit](https://img.shields.io/github/last-commit/phmatray/TaLibStandard)](https://github.com/phmatray/TaLibStandard/commits/master)
+[![CI/CD](https://github.com/phmatray/TaLibStandard/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/phmatray/TaLibStandard/actions/workflows/ci-cd.yml)
 [![codecov](https://codecov.io/gh/phmatray/TaLibStandard/branch/main/graph/badge.svg?token=041C4QKW6O)](https://app.codecov.io/gh/phmatray/TaLibStandard/tree/main)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/84e2475f22a04bc1bed551f081029e82)](https://app.codacy.com/gh/phmatray/TaLibStandard/dashboard)
 


### PR DESCRIPTION
Adds GitHub Actions CI/CD workflow badge to improve visibility of build status.

Quick win to improve repository documentation and show continuous integration status at a glance.