### PR TITLE
ci: publish to NuGet via Trusted Publishing, not a long-lived key

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -178,11 +178,23 @@ jobs:
         skip-commit: true
         output-file: false
 
+    # Trusted Publishing: no long-lived API key. The login step exchanges this workflow's OIDC
+    # token (permissions.id-token: write, declared at workflow level and inherited by this job) for
+    # a NuGet key valid ~1 hour, so it must stay adjacent to the push below. Requires a Trusted
+    # Publishing policy on nuget.org covering all four Atypical.TechnicalAnalysis* ids, naming this
+    # repository and ci-cd.yml, plus the NUGET_USER secret (the nuget.org profile name).
+    - name: NuGet login (OIDC -> short-lived key)
+      id: nuget-login
+      if: steps.should_release.outputs.new_release == 'true'
+      uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Push to NuGet
       if: steps.should_release.outputs.new_release == 'true'
       run: |
         dotnet nuget push "./artifacts/*.nupkg" \
-          --api-key "${{ secrets.NUGET_API_KEY }}" \
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" \
           --source "https://api.nuget.org/v3/index.json" \
           --skip-duplicate
     


### PR DESCRIPTION
The `release` job pushed with a long-lived `NUGET_API_KEY` secret. It now uses **Trusted Publishing**: GitHub's OIDC token is exchanged for a NuGet key valid ~1 hour, used immediately. The only remaining secret is `NUGET_USER` — your nuget.org profile name, not a credential.

`permissions.id-token: write` was already declared at workflow level and the `release` job declares none of its own, so it inherits it — no permission change was needed.

### One thing here needs a decision, not just a form fill

This repo publishes **four** ids — `Atypical.TechnicalAnalysis`, `.Common`, `.Functions`, `.Candles` — and they are `Atypical.*` ids under a **`phmatray`** repository. The Trusted Publishing policy belongs to whichever nuget.org account actually owns those ids, and it names `phmatray/TaLibStandard` + `ci-cd.yml` either way. Worth confirming the ownership before the next release rather than at it.

### Required before the next release

1. Register the policy (covering all four ids) on nuget.org.
2. Set the `NUGET_USER` secret.
3. Cut one release, confirm all four packages appear, **then** delete `NUGET_API_KEY`.