### PR TITLE
ci: run the build on pull requests to the default branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### La CI de ce depot ne s'executait sur aucune pull request

La branche par defaut est **`dev`**, mais `ci-cd.yml` filtrait ses PR sur `[ main ]`.

GitHub n'evalue le declencheur `pull_request` que si la branche **cible** correspond au filtre : aucune PR vers la branche par defaut ne declenchait donc de build. Consequences mesurees :

- aucun check ne gardait les merges sur ce depot ;
- l'automerge Renovate ne pouvait jamais s'armer (il attend un check vert), d'ou l'accumulation de PR.

Le filtre de branche est retire de `pull_request` (convention du portfolio : une PR vers n'importe quelle branche declenche le build). **`push` est laisse intact** : le repointer ferait tourner la CI sur la branche par defaut, ou un echec preexistant s'afficherait en rouge.

Cette PR est son propre test : le check qui apparait ci-dessous est la preuve que le declencheur fonctionne. Merge uniquement s'il est vert.