### PR TITLE
fix: unbreak the Debug build of the Blazor demo (fixes CodeQL on dev)

### DIFF
--- a/Demo.BlazorWasm/Demo.BlazorWasm.csproj
+++ b/Demo.BlazorWasm/Demo.BlazorWasm.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly"/>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all"/>
-    <PackageReference Include="Microsoft.DotNet.HotReload.WebAssembly.Browser" />
     <PackageReference Include="MudBlazor" />
     <PackageReference Include="PublishSPAforGitHubPages.Build" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
     <!-- Build Tools -->
     <PackageVersion Include="DotNet.ReproducibleBuilds" Version="2.0.5" />
-    <PackageVersion Include="Microsoft.DotNet.HotReload.WebAssembly.Browser" Version="10.0.204" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <!-- Documentation -->
     <PackageVersion Include="DefaultDocumentation" Version="1.2.5" />


### PR DESCRIPTION
## The reported symptom was misleading

CodeQL reported:

> We were unable to automatically build your code. Please change the build mode for this language to manual and specify build steps for your project.

That is autobuild's **generic** message, and it sent us toward reconfiguring code scanning. The actual cause is a real build break in this repository:

```
Microsoft.NET.Sdk.WebAssembly.Browser.targets(395,5): error : System.ArgumentException:
An item with the same key has already been added.
Key: .../bin/Debug/net10.0/wwwroot/_framework/Microsoft.DotNet.HotReload.WebAssembly.Browser.<hash>.wasm
   at Microsoft.NET.Sdk.WebAssembly.GenerateWasmBootJson.WriteBootConfig
```

No CodeQL configuration change is needed. Default setup is fine.

## Why it hid for so long

`Demo.BlazorWasm` referenced `Microsoft.DotNet.HotReload.WebAssembly.Browser` explicitly, and the Blazor WebAssembly SDK **already injects that package itself** for Debug builds. The asset gets contributed twice and `GenerateWasmBootJson` throws on the duplicate key.

Release builds never inject the hot-reload asset — so:

| | Debug | Release |
|---|---|---|
| `Demo.BlazorWasm` | **failed** | passed |
| CI/CD workflow | not run | ✅ green |
| CodeQL autobuild | ❌ **fails here** | not run |

CI builds `--configuration Release` and stayed green throughout. CodeQL's autobuild builds Debug. That is the entire discrepancy, and it is also why `dev` shows a red CodeQL run while every CI run is green.

## The fix

Drop the explicit `PackageReference` (and the now-unreferenced `PackageVersion`), leaving the SDK to supply and version the package — which is what it does for every other Blazor WebAssembly app. Hot reload under `dotnet watch` is unaffected.

Two lines removed.

## Verification

Reproduced locally first (identical `ArgumentException` on the same MSBuild target), then confirmed fixed in **both** configurations:

```
dotnet build TaLibStandard.sln -c Debug    ->  Build succeeded, 0 Error(s)   (previously failed)
dotnet build TaLibStandard.sln -c Release  ->  Build succeeded, 0 Error(s)   (unchanged)
```

Worth noting the gap this exposes: CI only ever builds Release, so a Debug-only break reaches the default branch unnoticed. Adding a Debug leg to the CI matrix would have caught this — happy to do that separately if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)