### PR TITLE
fix: clear the analyzer warnings in src

### DIFF
--- a/src/TechnicalAnalysis.Common/Abstractions/CandleIndicator.cs
+++ b/src/TechnicalAnalysis.Common/Abstractions/CandleIndicator.cs
@@ -11,44 +11,34 @@ namespace TechnicalAnalysis.Common;
 /// <summary>
 /// Represents an abstract base class for candlestick pattern recognition indicators.
 /// </summary>
-public abstract class CandleIndicator<T>
+/// <typeparam name="T">The floating-point type the price arrays are expressed in.</typeparam>
+/// <param name="open">An array of open prices.</param>
+/// <param name="high">An array of high prices.</param>
+/// <param name="low">An array of low prices.</param>
+/// <param name="close">An array of close prices.</param>
+public abstract class CandleIndicator<T>(T[] open, T[] high, T[] low, T[] close)
     where T : IFloatingPoint<T>
 {
     /// <summary>
     /// An array of open prices.
     /// </summary>
-    protected T[] Open { get; }
-        
+    protected T[] Open { get; } = open;
+
     /// <summary>
     /// An array of high prices.
     /// </summary>
-    protected T[] High { get; }
-        
+    protected T[] High { get; } = high;
+
     /// <summary>
     /// An array of low prices.
     /// </summary>
-    protected T[] Low { get; }
+    protected T[] Low { get; } = low;
         
     /// <summary>
     /// An array of close prices.
     /// </summary>
-    protected T[] Close { get; }
-        
-    /// <summary>
-    /// Initializes a new instance of the CandleIndicator class.
-    /// </summary>
-    /// <param name="open">An array of open prices.</param>
-    /// <param name="high">An array of high prices.</param>
-    /// <param name="low">An array of low prices.</param>
-    /// <param name="close">An array of close prices.</param>
-    protected CandleIndicator(T[] open, T[] high, T[] low, T[] close)
-    {
-        Open = open;
-        High = high;
-        Low = low;
-        Close = close;
-    }
-        
+    protected T[] Close { get; } = close;
+
     /// <summary>
     /// Returns the lookback period for the indicator.
     /// </summary>

--- a/src/TechnicalAnalysis.Common/Helpers/ValidationHelper.cs
+++ b/src/TechnicalAnalysis.Common/Helpers/ValidationHelper.cs
@@ -37,17 +37,9 @@ public static class ValidationHelper
     /// </returns>
     public static RetCode ValidateIndexRange(int startIdx, int endIdx)
     {
-        if (startIdx < 0)
-        {
-            return OutOfRangeStartIndex;
-        }
-
-        if (endIdx < 0 || endIdx < startIdx)
-        {
-            return OutOfRangeEndIndex;
-        }
-
-        return Success;
+        return startIdx < 0 ? OutOfRangeStartIndex
+            : endIdx < 0 || endIdx < startIdx ? OutOfRangeEndIndex
+            : Success;
     }
 
     /// <summary>
@@ -151,24 +143,15 @@ public static class ValidationHelper
         int minPeriod = 2,
         int maxPeriod = 100000)
     {
-        RetCode indexCheck = ValidateIndexRange(startIdx, endIdx);
-        if (indexCheck != Success)
-        {
-            return indexCheck;
-        }
-
-        RetCode arrayCheck = ValidateArrays(inReal, outReal);
-        if (arrayCheck != Success)
-        {
-            return arrayCheck;
-        }
-
-        if (optInTimePeriod.HasValue)
-        {
-            return ValidatePeriodRange(optInTimePeriod.Value, minPeriod, maxPeriod);
-        }
-
-        return Success;
+        // ValidateAll runs these in order and stops at the first failure, which is what the
+        // hand-rolled guard chain did — but as one expression, and matching how the indicators
+        // themselves compose their validation.
+        return ValidateAll(
+            () => ValidateIndexRange(startIdx, endIdx),
+            () => ValidateArrays(inReal, outReal),
+            () => optInTimePeriod.HasValue
+                ? ValidatePeriodRange(optInTimePeriod.Value, minPeriod, maxPeriod)
+                : Success);
     }
 
     /// <summary>

--- a/src/TechnicalAnalysis.Functions/Correl/CorrelResult.cs
+++ b/src/TechnicalAnalysis.Functions/Correl/CorrelResult.cs
@@ -30,14 +30,4 @@ public record CorrelResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of correlation coefficient values.
-    /// </summary>
-    /// <value>
-    /// An array of doubles representing the correlation values, ranging from -1 to +1. 
-    /// Values near +1 indicate strong positive correlation, values near -1 indicate 
-    /// strong negative correlation, and values near 0 indicate weak or no linear relationship. 
-    /// These values are essential for risk management and portfolio optimization.
-    /// </value>
 }

--- a/src/TechnicalAnalysis.Functions/Dx/DxResult.cs
+++ b/src/TechnicalAnalysis.Functions/Dx/DxResult.cs
@@ -10,6 +10,11 @@ namespace TechnicalAnalysis.Functions;
 /// Represents the result of the Directional Movement Index (DX) indicator calculation.
 /// DX measures the strength of a trend regardless of its direction, derived from comparing directional movements.
 /// </summary>
+/// <remarks>
+/// The <see cref="SingleOutputResult.Real"/> array holds the Directional Movement Index values.
+/// Values range from 0 to 100, where higher values indicate stronger trends (either up or down).
+/// Values below 20 typically indicate weak trends, while values above 40 suggest strong trends.
+/// </remarks>
 public record DxResult : SingleOutputResult
 {
     /// <summary>
@@ -23,10 +28,4 @@ public record DxResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of Directional Movement Index values.
-    /// Values range from 0 to 100, where higher values indicate stronger trends (either up or down).
-    /// Values below 20 typically indicate weak trends, while values above 40 suggest strong trends.
-    /// </summary>
 }

--- a/src/TechnicalAnalysis.Functions/HtDcPeriod/HtDcPeriodResult.cs
+++ b/src/TechnicalAnalysis.Functions/HtDcPeriod/HtDcPeriodResult.cs
@@ -11,6 +11,11 @@ namespace TechnicalAnalysis.Functions;
 /// This indicator identifies the dominant cycle period of market data using Hilbert Transform techniques,
 /// providing insight into the cyclical nature of price movements.
 /// </summary>
+/// <remarks>
+/// The <see cref="SingleOutputResult.Real"/> array holds the dominant cycle period values.
+/// Each value represents the period (in bars) of the dominant market cycle at that point in time.
+/// Values typically range from 10 to 50 bars, depending on market conditions.
+/// </remarks>
 public record HtDcPeriodResult : SingleOutputResult
 {
     /// <summary>
@@ -24,10 +29,4 @@ public record HtDcPeriodResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of dominant cycle period values.
-    /// Each value represents the period (in bars) of the dominant market cycle at that point in time.
-    /// Values typically range from 10 to 50 bars, depending on market conditions.
-    /// </summary>
 }

--- a/src/TechnicalAnalysis.Functions/HtDcPhase/HtDcPhaseResult.cs
+++ b/src/TechnicalAnalysis.Functions/HtDcPhase/HtDcPhaseResult.cs
@@ -11,6 +11,11 @@ namespace TechnicalAnalysis.Functions;
 /// This indicator measures the phase angle of the dominant market cycle using Hilbert Transform techniques,
 /// helping to identify the current position within a price cycle.
 /// </summary>
+/// <remarks>
+/// The <see cref="SingleOutputResult.Real"/> array holds the dominant cycle phase values.
+/// Each value represents the phase angle in degrees (-180 to +180) of the dominant cycle.
+/// Positive values indicate the cycle is in an upward phase, while negative values indicate a downward phase.
+/// </remarks>
 public record HtDcPhaseResult : SingleOutputResult
 {
     /// <summary>
@@ -24,10 +29,4 @@ public record HtDcPhaseResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of dominant cycle phase values.
-    /// Each value represents the phase angle in degrees (-180 to +180) of the dominant cycle.
-    /// Positive values indicate the cycle is in an upward phase, while negative values indicate a downward phase.
-    /// </summary>
 }

--- a/src/TechnicalAnalysis.Functions/HtTrendline/HtTrendlineResult.cs
+++ b/src/TechnicalAnalysis.Functions/HtTrendline/HtTrendlineResult.cs
@@ -11,6 +11,11 @@ namespace TechnicalAnalysis.Functions;
 /// This indicator creates a smooth trendline by removing the dominant cycle component from price data,
 /// effectively filtering out short-term fluctuations to reveal the underlying trend.
 /// </summary>
+/// <remarks>
+/// The <see cref="SingleOutputResult.Real"/> array holds the instantaneous trendline values.
+/// These values represent a smoothed version of the price with dominant cycles filtered out,
+/// providing a clear view of the underlying trend direction and strength.
+/// </remarks>
 public record HtTrendlineResult : SingleOutputResult
 {
     /// <summary>
@@ -24,10 +29,4 @@ public record HtTrendlineResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of instantaneous trendline values.
-    /// These values represent a smoothed version of the price with dominant cycles filtered out,
-    /// providing a clear view of the underlying trend direction and strength.
-    /// </summary>
 }

--- a/src/TechnicalAnalysis.Functions/LinearReg/LinearRegResult.cs
+++ b/src/TechnicalAnalysis.Functions/LinearReg/LinearRegResult.cs
@@ -11,6 +11,11 @@ namespace TechnicalAnalysis.Functions;
 /// This indicator calculates the linear regression line value at each point, providing a statistical
 /// best-fit line through the price data over a specified period.
 /// </summary>
+/// <remarks>
+/// The <see cref="SingleOutputResult.Real"/> array holds the linear regression line values.
+/// Each value represents the y-coordinate of the regression line at that point in time,
+/// calculated using least squares method over the specified lookback period.
+/// </remarks>
 public record LinearRegResult : SingleOutputResult
 {
     /// <summary>
@@ -24,10 +29,4 @@ public record LinearRegResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of linear regression line values.
-    /// Each value represents the y-coordinate of the regression line at that point in time,
-    /// calculated using least squares method over the specified lookback period.
-    /// </summary>
 }

--- a/src/TechnicalAnalysis.Functions/LinearRegAngle/LinearRegAngleResult.cs
+++ b/src/TechnicalAnalysis.Functions/LinearRegAngle/LinearRegAngleResult.cs
@@ -11,6 +11,11 @@ namespace TechnicalAnalysis.Functions;
 /// This indicator calculates the angle of the linear regression line in degrees, providing insight
 /// into the strength and direction of the trend over a specified period.
 /// </summary>
+/// <remarks>
+/// Gets the array of linear regression angle values in degrees.
+/// Positive angles indicate an upward trend, negative angles indicate a downward trend.
+/// The magnitude of the angle reflects the steepness of the trend.
+/// </remarks>
 public record LinearRegAngleResult : SingleOutputResult
 {
     /// <summary>
@@ -24,10 +29,4 @@ public record LinearRegAngleResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of linear regression angle values in degrees.
-    /// Positive angles indicate an upward trend, negative angles indicate a downward trend.
-    /// The magnitude of the angle reflects the steepness of the trend.
-    /// </summary>
 }

--- a/src/TechnicalAnalysis.Functions/LinearRegIntercept/LinearRegInterceptResult.cs
+++ b/src/TechnicalAnalysis.Functions/LinearRegIntercept/LinearRegInterceptResult.cs
@@ -11,6 +11,11 @@ namespace TechnicalAnalysis.Functions;
 /// This indicator calculates the y-intercept of the linear regression line, representing where
 /// the regression line would cross the y-axis if extended backward.
 /// </summary>
+/// <remarks>
+/// The <see cref="SingleOutputResult.Real"/> array holds the linear regression intercept values.
+/// Each value represents the y-intercept of the regression line calculated over the lookback period,
+/// useful for projecting the regression line and understanding price levels.
+/// </remarks>
 public record LinearRegInterceptResult : SingleOutputResult
 {
     /// <summary>
@@ -24,10 +29,4 @@ public record LinearRegInterceptResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of linear regression intercept values.
-    /// Each value represents the y-intercept of the regression line calculated over the lookback period,
-    /// useful for projecting the regression line and understanding price levels.
-    /// </summary>
 }

--- a/src/TechnicalAnalysis.Functions/LinearRegSlope/LinearRegSlopeResult.cs
+++ b/src/TechnicalAnalysis.Functions/LinearRegSlope/LinearRegSlopeResult.cs
@@ -11,6 +11,11 @@ namespace TechnicalAnalysis.Functions;
 /// This indicator calculates the slope of the linear regression line, indicating the rate of change
 /// in price over the specified period.
 /// </summary>
+/// <remarks>
+/// The <see cref="SingleOutputResult.Real"/> array holds the linear regression slope values.
+/// Each value represents the slope (rate of change per bar) of the regression line.
+/// Positive values indicate rising prices, negative values indicate falling prices.
+/// </remarks>
 public record LinearRegSlopeResult : SingleOutputResult
 {
     /// <summary>
@@ -24,10 +29,4 @@ public record LinearRegSlopeResult : SingleOutputResult
         : base(retCode, begIdx, nbElement, real)
     {
     }
-
-    /// <summary>
-    /// Gets the array of linear regression slope values.
-    /// Each value represents the slope (rate of change per bar) of the regression line.
-    /// Positive values indicate rising prices, negative values indicate falling prices.
-    /// </summary>
 }

--- a/src/TechnicalAnalysis.Functions/MacdFix/TAMath.cs
+++ b/src/TechnicalAnalysis.Functions/MacdFix/TAMath.cs
@@ -51,9 +51,10 @@ public static partial class TAMath
     /// <param name="startIdx">The starting index for the calculation range.</param>
     /// <param name="endIdx">The ending index for the calculation range.</param>
     /// <param name="real">Array of input values (usually closing prices).</param>
+    /// <param name="signalPeriod">The signal line period. Defaults to 9.</param>
     /// <returns>A MacdFixResult containing the MACD line, signal line, and histogram values.</returns>
     /// <remarks>
-    /// Uses fixed values: fastPeriod=12, slowPeriod=26, signalPeriod=9.
+    /// The fast and slow periods are fixed at 12 and 26; only the signal period is adjustable.
     /// </remarks>
     public static MacdFixResult MacdFix(int startIdx, int endIdx, float[] real, int signalPeriod = 9)
         => TAMathHelper.Execute(startIdx, endIdx, real, (s, e, r) => MacdFix(s, e, r, signalPeriod));

--- a/src/TechnicalAnalysis.Functions/MidPrice/TAMath.cs
+++ b/src/TechnicalAnalysis.Functions/MidPrice/TAMath.cs
@@ -50,6 +50,7 @@ public static partial class TAMath
     /// <param name="endIdx">The ending index for the calculation range.</param>
     /// <param name="high">Array of high prices.</param>
     /// <param name="low">Array of low prices.</param>
+    /// <param name="timePeriod">The number of periods in each rolling window. Defaults to 14.</param>
     /// <returns>A MidPriceResult containing the midprice values over each rolling window.</returns>
     /// <remarks>
     /// This overload uses a default time period of 14.

--- a/src/TechnicalAnalysis.Functions/Natr/TAMath.cs
+++ b/src/TechnicalAnalysis.Functions/Natr/TAMath.cs
@@ -55,6 +55,7 @@ public static partial class TAMath
     /// <param name="high">An array of high prices.</param>
     /// <param name="low">An array of low prices.</param>
     /// <param name="close">An array of closing prices.</param>
+    /// <param name="timePeriod">The number of periods to average over. Defaults to 14.</param>
     /// <returns>A NatrResult object containing the calculated values.</returns>
     /// <remarks>Uses the default time period of 14.</remarks>
     public static NatrResult Natr(int startIdx, int endIdx, float[] high, float[] low, float[] close, int timePeriod = 14)

--- a/src/TechnicalAnalysis.Functions/ZigZag/TAMath.cs
+++ b/src/TechnicalAnalysis.Functions/ZigZag/TAMath.cs
@@ -57,6 +57,7 @@ public static partial class TAMath
     /// <param name="endIdx">The ending index for the calculation.</param>
     /// <param name="high">Array of high prices.</param>
     /// <param name="low">Array of low prices.</param>
+    /// <param name="deviation">The minimum percentage move required to start a new leg. Defaults to 5.0.</param>
     /// <returns>A ZigZagResult object containing the calculated values and metadata.</returns>
     public static ZigZagResult ZigZag(int startIdx, int endIdx, float[] high, float[] low, double deviation = 5.0)
         => TAMathHelper.Execute(startIdx, endIdx, high, low, (s, e, h, l) => ZigZag(s, e, h, l, deviation));


### PR DESCRIPTION
Clears every instance of the four warning classes CI reported. GitHub caps annotations at 10 per job, so the reported list was a subset — this covers all of them.

| Warning | Reported | Actually present | Fixed |
|---|---|---|---|
| CS1587 — XML comment not on a valid element | 3 | **9** | 9 |
| CS1573 — missing `<param>` tag | 4 | 4 | 4 |
| IDE0290 — use primary constructor | 1 | 1 | 1 |
| IDE0046 — `if` can be simplified | 2 | 2 | 2 |

## CS1587 — nine result records

Each file ended with a documentation block describing the inherited `Real` property, sitting after the last member with no element to attach to.

The text was useful domain detail — the range DX takes, what a dominant-cycle period means — so it moved into the class-level `<remarks>` rather than being deleted:

```csharp
/// <remarks>
/// The <see cref="SingleOutputResult.Real"/> array holds the Directional Movement Index values.
/// Values range from 0 to 100, where higher values indicate stronger trends (either up or down).
/// Values below 20 typically indicate weak trends, while values above 40 suggest strong trends.
/// </remarks>
```

`CorrelResult`'s block only restated what its existing `<remarks>` already said, so that one is simply removed.

## CS1573 — four `float[]` overloads

Each takes an optional parameter the documentation never mentioned. One of them was actively misleading: `MacdFix` claimed *"Uses fixed values: fastPeriod=12, slowPeriod=26, signalPeriod=9"* while `signalPeriod` was in fact a settable parameter. It now says the fast and slow periods are fixed and the signal period is adjustable.

## IDE0290 — `CandleIndicator<T>`

Converted to a primary constructor, with the parameter documentation moved onto the type. The generated constructor signature is unchanged, so this is source **and** binary compatible — and it's the base class for all 61 candlestick patterns, so the 673 candle tests are the real check.

## IDE0046 — `ValidationHelper`

`ValidateIndexRange` becomes a conditional cascade.

`ValidateSingleInputIndicator` was a hand-rolled guard chain. Rather than nest three ternaries to satisfy the analyzer, it now calls the **`ValidateAll` helper this same class already exposes** and the indicators already use (see `Atr/TAFunc.cs`):

```csharp
return ValidateAll(
    () => ValidateIndexRange(startIdx, endIdx),
    () => ValidateArrays(inReal, outReal),
    () => optInTimePeriod.HasValue
        ? ValidatePeriodRange(optInTimePeriod.Value, minPeriod, maxPeriod)
        : Success);
```

One expression, still short-circuiting at the first failure, and lazier than the original — each check now only runs if the previous one passed.

## Verification

```
dotnet build TaLibStandard.sln -c Release   ->  0 errors
grep for CS1587|CS1573|IDE0290|IDE0046 in src  ->  no matches

dotnet test TaLibStandard.sln -c Release
  Candles.UnitTests              673 passed
  Functions.UnitTests            232 passed
  Samples.Backtesting.UnitTests  220 passed
  ->  1125 passed, 0 failed
```

## One thing to know

The generated pages under `docs/functions/` and `docs/common/` now **lag these XML comment changes**. I deliberately did not regenerate them: this machine emits different character encoding than the committed output (`&#129106;` vs `→`), so regenerating would bury a 15-file change under ~175 spurious diffs — exactly what went wrong on #106.

They should be regenerated on a machine whose encoding matches, or the encoding should be pinned so this stops being a trap for contributors.

Worth noting on the IDE0046 rule specifically: `.editorconfig` line 83 sets `dotnet_style_prefer_conditional_expression_over_return = true:silent`, but `AnalysisModeStyle=All` in `Directory.Build.props` escalates it to a warning anyway. The .editorconfig's stated intent is being overridden. Worth reconciling those two if the style rules keep surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)