### PR TITLE
fix: correct the directional movement seeding off-by-one

### DIFF
--- a/src/TechnicalAnalysis.Functions/Adx/TAFunc.cs
+++ b/src/TechnicalAnalysis.Functions/Adx/TAFunc.cs
@@ -81,15 +81,14 @@ public static partial class TAFunc
         double prevHigh = inHigh[today];
         double prevLow = inLow[today];
         double prevClose = inClose[today];
+        // The reference implementation seeds with `while (i-- > 0)`, which executes the body
+        // exactly `i` times. Translating it as `while (true) { i--; if (i <= 0) break; ... }`
+        // executes it `i - 1` times, which leaves `today` short of startIdx and makes the tail
+        // loop emit that many extra values: outBegIdx + outNBElement then overruns the input.
         int i = optInTimePeriod - 1;
-        while (true)
+        while (i > 0)
         {
             i--;
-            if (i <= 0)
-            {
-                break;
-            }
-
             today++;
             tempReal = inHigh[today];
             diffP = tempReal - prevHigh;
@@ -125,14 +124,9 @@ public static partial class TAFunc
 
         double sumDX = 0.0;
         i = optInTimePeriod;
-        while (true)
+        while (i > 0)
         {
             i--;
-            if (i <= 0)
-            {
-                break;
-            }
-
             today++;
             tempReal = inHigh[today];
             diffP = tempReal - prevHigh;
@@ -174,14 +168,9 @@ public static partial class TAFunc
 
         double prevADX = sumDX / optInTimePeriod;
         i = (int)TACore.Globals.UnstablePeriod[FuncUnstId.Adx];
-        while (true)
+        while (i > 0)
         {
             i--;
-            if (i <= 0)
-            {
-                break;
-            }
-
             today++;
             tempReal = inHigh[today];
             diffP = tempReal - prevHigh;

--- a/src/TechnicalAnalysis.Functions/Dx/TAFunc.cs
+++ b/src/TechnicalAnalysis.Functions/Dx/TAFunc.cs
@@ -104,15 +104,14 @@ public static partial class TAFunc
         double prevHigh = inHigh[today];
         double prevLow = inLow[today];
         double prevClose = inClose[today];
+        // The reference implementation seeds with `while (i-- > 0)`, which executes the body
+        // exactly `i` times. Translating it as `while (true) { i--; if (i <= 0) break; ... }`
+        // executes it `i - 1` times, which leaves `today` short of startIdx and makes the tail
+        // loop emit that many extra values: outBegIdx + outNBElement then overruns the input.
         int i = optInTimePeriod - 1;
-        while (true)
+        while (i > 0)
         {
             i--;
-            if (i <= 0)
-            {
-                break;
-            }
-
             today++;
             tempReal = inHigh[today];
             diffP = tempReal - prevHigh;
@@ -146,15 +145,11 @@ public static partial class TAFunc
             prevClose = inClose[today];
         }
 
+        // Likewise `while (i-- != 0)`, which executes the body exactly `i` times.
         i = (int)TACore.Globals.UnstablePeriod[FuncUnstId.Dx] + 1;
-        while (true)
+        while (i != 0)
         {
             i--;
-            if (i == 0)
-            {
-                break;
-            }
-
             today++;
             tempReal = inHigh[today];
             diffP = tempReal - prevHigh;

--- a/src/TechnicalAnalysis.Functions/MinusDI/TAFunc.cs
+++ b/src/TechnicalAnalysis.Functions/MinusDI/TAFunc.cs
@@ -95,102 +95,20 @@ public static partial class TAFunc
             double prevHigh = inHigh[today];
             double prevLow = inLow[today];
             double prevClose = inClose[today];
+            double tempReal;
+            double tempReal2;
+            double diffM;
+            double diffP;
+
+            // The reference implementation seeds with `while (i-- > 0)` and then smooths with
+            // `while (i-- != 0)`; each executes its body exactly `i` times. Translating either as
+            // `while (true) { i--; if (i <= 0) break; ... }` executes it `i - 1` times, which leaves
+            // `today` short of startIdx and makes the tail loop emit that many extra values, so that
+            // outBegIdx + outNBElement overruns the input.
             int i = optInTimePeriod - 1;
-            while (true)
+            while (i > 0)
             {
                 i--;
-                double tempReal;
-                double tempReal2;
-                double diffM;
-                double diffP;
-                if (i <= 0)
-                {
-                    i = (int)TACore.Globals.UnstablePeriod[FuncUnstId.MinusDI] + 1;
-                    while (true)
-                    {
-                        i--;
-                        if (i == 0)
-                        {
-                            break;
-                        }
-
-                        today++;
-                        tempReal = inHigh[today];
-                        diffP = tempReal - prevHigh;
-                        prevHigh = tempReal;
-                        tempReal = inLow[today];
-                        diffM = prevLow - tempReal;
-                        prevLow = tempReal;
-                        if (diffM > 0.0 && diffP < diffM)
-                        {
-                            prevMinusDM = prevMinusDM - (prevMinusDM / optInTimePeriod) + diffM;
-                        }
-                        else
-                        {
-                            prevMinusDM -= prevMinusDM / optInTimePeriod;
-                        }
-
-                        tempReal = prevHigh - prevLow;
-                        tempReal2 = Math.Abs(prevHigh - prevClose);
-                        if (tempReal2 > tempReal)
-                        {
-                            tempReal = tempReal2;
-                        }
-
-                        tempReal2 = Math.Abs(prevLow - prevClose);
-                        if (tempReal2 > tempReal)
-                        {
-                            tempReal = tempReal2;
-                        }
-
-                        prevTR = prevTR - (prevTR / optInTimePeriod) + tempReal;
-                        prevClose = inClose[today];
-                    }
-
-                    outReal[0] = 100.0 * (prevMinusDM / prevTR);
-
-                    outIdx = 1;
-                    while (today < endIdx)
-                    {
-                        today++;
-                        tempReal = inHigh[today];
-                        diffP = tempReal - prevHigh;
-                        prevHigh = tempReal;
-                        tempReal = inLow[today];
-                        diffM = prevLow - tempReal;
-                        prevLow = tempReal;
-                        if (diffM > 0.0 && diffP < diffM)
-                        {
-                            prevMinusDM = prevMinusDM - (prevMinusDM / optInTimePeriod) + diffM;
-                        }
-                        else
-                        {
-                            prevMinusDM -= prevMinusDM / optInTimePeriod;
-                        }
-
-                        tempReal = prevHigh - prevLow;
-                        tempReal2 = Math.Abs(prevHigh - prevClose);
-                        if (tempReal2 > tempReal)
-                        {
-                            tempReal = tempReal2;
-                        }
-
-                        tempReal2 = Math.Abs(prevLow - prevClose);
-                        if (tempReal2 > tempReal)
-                        {
-                            tempReal = tempReal2;
-                        }
-
-                        prevTR = prevTR - (prevTR / optInTimePeriod) + tempReal;
-                        prevClose = inClose[today];
-                        outReal[outIdx] = 100.0 * (prevMinusDM / prevTR);
-                        outIdx++;
-                    }
-
-                    outNBElement = outIdx;
-                    return Success;
-                }
-
                 today++;
                 tempReal = inHigh[today];
                 diffP = tempReal - prevHigh;
@@ -219,6 +137,86 @@ public static partial class TAFunc
                 prevTR += tempReal;
                 prevClose = inClose[today];
             }
+
+            i = (int)TACore.Globals.UnstablePeriod[FuncUnstId.MinusDI] + 1;
+            while (i != 0)
+            {
+                i--;
+                today++;
+                tempReal = inHigh[today];
+                diffP = tempReal - prevHigh;
+                prevHigh = tempReal;
+                tempReal = inLow[today];
+                diffM = prevLow - tempReal;
+                prevLow = tempReal;
+                if (diffM > 0.0 && diffP < diffM)
+                {
+                    prevMinusDM = prevMinusDM - (prevMinusDM / optInTimePeriod) + diffM;
+                }
+                else
+                {
+                    prevMinusDM -= prevMinusDM / optInTimePeriod;
+                }
+
+                tempReal = prevHigh - prevLow;
+                tempReal2 = Math.Abs(prevHigh - prevClose);
+                if (tempReal2 > tempReal)
+                {
+                    tempReal = tempReal2;
+                }
+
+                tempReal2 = Math.Abs(prevLow - prevClose);
+                if (tempReal2 > tempReal)
+                {
+                    tempReal = tempReal2;
+                }
+
+                prevTR = prevTR - (prevTR / optInTimePeriod) + tempReal;
+                prevClose = inClose[today];
+            }
+
+            outReal[0] = 100.0 * (prevMinusDM / prevTR);
+
+            outIdx = 1;
+            while (today < endIdx)
+            {
+                today++;
+                tempReal = inHigh[today];
+                diffP = tempReal - prevHigh;
+                prevHigh = tempReal;
+                tempReal = inLow[today];
+                diffM = prevLow - tempReal;
+                prevLow = tempReal;
+                if (diffM > 0.0 && diffP < diffM)
+                {
+                    prevMinusDM = prevMinusDM - (prevMinusDM / optInTimePeriod) + diffM;
+                }
+                else
+                {
+                    prevMinusDM -= prevMinusDM / optInTimePeriod;
+                }
+
+                tempReal = prevHigh - prevLow;
+                tempReal2 = Math.Abs(prevHigh - prevClose);
+                if (tempReal2 > tempReal)
+                {
+                    tempReal = tempReal2;
+                }
+
+                tempReal2 = Math.Abs(prevLow - prevClose);
+                if (tempReal2 > tempReal)
+                {
+                    tempReal = tempReal2;
+                }
+
+                prevTR = prevTR - (prevTR / optInTimePeriod) + tempReal;
+                prevClose = inClose[today];
+                outReal[outIdx] = 100.0 * (prevMinusDM / prevTR);
+                outIdx++;
+            }
+
+            outNBElement = outIdx;
+            return Success;
         }
 
         outBegIdx = startIdx;

--- a/src/TechnicalAnalysis.Functions/PlusDI/TAFunc.cs
+++ b/src/TechnicalAnalysis.Functions/PlusDI/TAFunc.cs
@@ -95,102 +95,20 @@ public static partial class TAFunc
             double prevHigh = inHigh[today];
             double prevLow = inLow[today];
             double prevClose = inClose[today];
+            double tempReal;
+            double tempReal2;
+            double diffP;
+            double diffM;
+
+            // The reference implementation seeds with `while (i-- > 0)` and then smooths with
+            // `while (i-- != 0)`; each executes its body exactly `i` times. Translating either as
+            // `while (true) { i--; if (i <= 0) break; ... }` executes it `i - 1` times, which leaves
+            // `today` short of startIdx and makes the tail loop emit that many extra values, so that
+            // outBegIdx + outNBElement overruns the input.
             int i = optInTimePeriod - 1;
-            while (true)
+            while (i > 0)
             {
                 i--;
-                double tempReal;
-                double tempReal2;
-                double diffP;
-                double diffM;
-                if (i <= 0)
-                {
-                    i = (int)TACore.Globals.UnstablePeriod[FuncUnstId.PlusDI] + 1;
-                    while (true)
-                    {
-                        i--;
-                        if (i == 0)
-                        {
-                            break;
-                        }
-
-                        today++;
-                        tempReal = inHigh[today];
-                        diffP = tempReal - prevHigh;
-                        prevHigh = tempReal;
-                        tempReal = inLow[today];
-                        diffM = prevLow - tempReal;
-                        prevLow = tempReal;
-                        if (diffP > 0.0 && diffP > diffM)
-                        {
-                            prevPlusDM = prevPlusDM - (prevPlusDM / optInTimePeriod) + diffP;
-                        }
-                        else
-                        {
-                            prevPlusDM -= prevPlusDM / optInTimePeriod;
-                        }
-
-                        tempReal = prevHigh - prevLow;
-                        tempReal2 = Math.Abs(prevHigh - prevClose);
-                        if (tempReal2 > tempReal)
-                        {
-                            tempReal = tempReal2;
-                        }
-
-                        tempReal2 = Math.Abs(prevLow - prevClose);
-                        if (tempReal2 > tempReal)
-                        {
-                            tempReal = tempReal2;
-                        }
-
-                        prevTR = prevTR - (prevTR / optInTimePeriod) + tempReal;
-                        prevClose = inClose[today];
-                    }
-
-                    outReal[0] = 100.0 * (prevPlusDM / prevTR);
-
-                    outIdx = 1;
-                    while (today < endIdx)
-                    {
-                        today++;
-                        tempReal = inHigh[today];
-                        diffP = tempReal - prevHigh;
-                        prevHigh = tempReal;
-                        tempReal = inLow[today];
-                        diffM = prevLow - tempReal;
-                        prevLow = tempReal;
-                        if (diffP > 0.0 && diffP > diffM)
-                        {
-                            prevPlusDM = prevPlusDM - (prevPlusDM / optInTimePeriod) + diffP;
-                        }
-                        else
-                        {
-                            prevPlusDM -= prevPlusDM / optInTimePeriod;
-                        }
-
-                        tempReal = prevHigh - prevLow;
-                        tempReal2 = Math.Abs(prevHigh - prevClose);
-                        if (tempReal2 > tempReal)
-                        {
-                            tempReal = tempReal2;
-                        }
-
-                        tempReal2 = Math.Abs(prevLow - prevClose);
-                        if (tempReal2 > tempReal)
-                        {
-                            tempReal = tempReal2;
-                        }
-
-                        prevTR = prevTR - (prevTR / optInTimePeriod) + tempReal;
-                        prevClose = inClose[today];
-                        outReal[outIdx] = 100.0 * (prevPlusDM / prevTR);
-                        outIdx++;
-                    }
-
-                    outNBElement = outIdx;
-                    return Success;
-                }
-
                 today++;
                 tempReal = inHigh[today];
                 diffP = tempReal - prevHigh;
@@ -219,6 +137,86 @@ public static partial class TAFunc
                 prevTR += tempReal;
                 prevClose = inClose[today];
             }
+
+            i = (int)TACore.Globals.UnstablePeriod[FuncUnstId.PlusDI] + 1;
+            while (i != 0)
+            {
+                i--;
+                today++;
+                tempReal = inHigh[today];
+                diffP = tempReal - prevHigh;
+                prevHigh = tempReal;
+                tempReal = inLow[today];
+                diffM = prevLow - tempReal;
+                prevLow = tempReal;
+                if (diffP > 0.0 && diffP > diffM)
+                {
+                    prevPlusDM = prevPlusDM - (prevPlusDM / optInTimePeriod) + diffP;
+                }
+                else
+                {
+                    prevPlusDM -= prevPlusDM / optInTimePeriod;
+                }
+
+                tempReal = prevHigh - prevLow;
+                tempReal2 = Math.Abs(prevHigh - prevClose);
+                if (tempReal2 > tempReal)
+                {
+                    tempReal = tempReal2;
+                }
+
+                tempReal2 = Math.Abs(prevLow - prevClose);
+                if (tempReal2 > tempReal)
+                {
+                    tempReal = tempReal2;
+                }
+
+                prevTR = prevTR - (prevTR / optInTimePeriod) + tempReal;
+                prevClose = inClose[today];
+            }
+
+            outReal[0] = 100.0 * (prevPlusDM / prevTR);
+
+            outIdx = 1;
+            while (today < endIdx)
+            {
+                today++;
+                tempReal = inHigh[today];
+                diffP = tempReal - prevHigh;
+                prevHigh = tempReal;
+                tempReal = inLow[today];
+                diffM = prevLow - tempReal;
+                prevLow = tempReal;
+                if (diffP > 0.0 && diffP > diffM)
+                {
+                    prevPlusDM = prevPlusDM - (prevPlusDM / optInTimePeriod) + diffP;
+                }
+                else
+                {
+                    prevPlusDM -= prevPlusDM / optInTimePeriod;
+                }
+
+                tempReal = prevHigh - prevLow;
+                tempReal2 = Math.Abs(prevHigh - prevClose);
+                if (tempReal2 > tempReal)
+                {
+                    tempReal = tempReal2;
+                }
+
+                tempReal2 = Math.Abs(prevLow - prevClose);
+                if (tempReal2 > tempReal)
+                {
+                    tempReal = tempReal2;
+                }
+
+                prevTR = prevTR - (prevTR / optInTimePeriod) + tempReal;
+                prevClose = inClose[today];
+                outReal[outIdx] = 100.0 * (prevPlusDM / prevTR);
+                outIdx++;
+            }
+
+            outNBElement = outIdx;
+            return Success;
         }
 
         outBegIdx = startIdx;

--- a/tests/TechnicalAnalysis.Functions.UnitTests/Func/DirectionalMovementRegressionTests.cs
+++ b/tests/TechnicalAnalysis.Functions.UnitTests/Func/DirectionalMovementRegressionTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) 2023 Philippe Matray. All rights reserved.
+// This file is part of TaLibStandard.
+// TaLibStandard is licensed under the GNU General Public License v3.0.
+// See the LICENSE file in the project root for the full license text.
+// For more information, visit https://github.com/phmatray/TaLibStandard.
+
+namespace TechnicalAnalysis.Functions.UnitTests.Func;
+
+/// <summary>
+/// Pins the directional movement family against the seeding off-by-one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The C reference seeds with <c>while (i-- &gt; 0)</c>, which runs its body <c>i</c> times. The C#
+/// transcription was <c>while (true) { i--; if (i &lt;= 0) break; ... }</c>, which runs it <c>i - 1</c>
+/// times. One term short, in the same shape as the EMA seed corrected in #105.
+/// </para>
+/// <para>
+/// It surfaced two ways. The undercount left the cursor short of <c>startIdx</c>, so
+/// <c>BegIdx + NBElement</c> came back as 102 over a 100-bar series — two values claimed for bars that
+/// do not exist, which silently misaligns every consumer that maps an output element onto a bar. And
+/// the ADX seed averaged 13 values while dividing by 14, so a series whose DX is a constant 100 read
+/// 92.857 and crept towards 100 without arriving.
+/// </para>
+/// <para>
+/// The existing AdxTests, DxTests, PlusDITests and MinusDITests assert only
+/// <see cref="RetCode.Success"/>, so none of this was detectable by the suite. These fixtures assert
+/// numbers.
+/// </para>
+/// </remarks>
+public class DirectionalMovementRegressionTests
+{
+    private const int BarCount = 100;
+    private const int Period = 14;
+
+    /// <summary>
+    /// A perfectly linear uptrend. Every bar gains exactly 2, so +DM is a constant 2 and -DM is zero;
+    /// the true range is a constant 2.5 (the gap from the previous close to this high). Wilder's
+    /// average of a constant is that constant, so +DI is exactly 100 * 2 / 2.5 = 80, -DI is exactly 0,
+    /// DX is exactly 100, and ADX — the smoothed average of a constant 100 — is exactly 100.
+    /// </summary>
+    private static (double[] High, double[] Low, double[] Close) LinearUptrend()
+    {
+        double[] high = new double[BarCount];
+        double[] low = new double[BarCount];
+        double[] close = new double[BarCount];
+
+        for (int i = 0; i < BarCount; i++)
+        {
+            high[i] = 100.0 + (2.0 * i);
+            low[i] = 99.0 + (2.0 * i);
+            close[i] = 99.5 + (2.0 * i);
+        }
+
+        return (high, low, close);
+    }
+
+    /// <summary>The mirror image of <see cref="LinearUptrend"/>: -DI is 80 and +DI is 0.</summary>
+    private static (double[] High, double[] Low, double[] Close) LinearDowntrend()
+    {
+        double[] high = new double[BarCount];
+        double[] low = new double[BarCount];
+        double[] close = new double[BarCount];
+
+        for (int i = 0; i < BarCount; i++)
+        {
+            high[i] = 100.0 - (2.0 * i);
+            low[i] = 99.0 - (2.0 * i);
+            close[i] = 99.5 - (2.0 * i);
+        }
+
+        return (high, low, close);
+    }
+
+    private static (RetCode RetCode, int BegIdx, int NBElement, double[] Real) Run(
+        Func<int, int, double[], double[], double[], int, (RetCode, int, int, double[])> call,
+        (double[] High, double[] Low, double[] Close) bars)
+    {
+        return call(0, BarCount - 1, bars.High, bars.Low, bars.Close, Period);
+    }
+
+    private static (RetCode, int, int, double[]) Adx(int s, int e, double[] h, double[] l, double[] c, int p)
+    {
+        int beg = 0;
+        int nb = 0;
+        double[] outReal = new double[BarCount];
+        RetCode rc = TAFunc.Adx(s, e, h, l, c, p, ref beg, ref nb, ref outReal);
+        return (rc, beg, nb, outReal);
+    }
+
+    private static (RetCode, int, int, double[]) Dx(int s, int e, double[] h, double[] l, double[] c, int p)
+    {
+        int beg = 0;
+        int nb = 0;
+        double[] outReal = new double[BarCount];
+        RetCode rc = TAFunc.Dx(s, e, h, l, c, p, ref beg, ref nb, ref outReal);
+        return (rc, beg, nb, outReal);
+    }
+
+    private static (RetCode, int, int, double[]) PlusDi(int s, int e, double[] h, double[] l, double[] c, int p)
+    {
+        int beg = 0;
+        int nb = 0;
+        double[] outReal = new double[BarCount];
+        RetCode rc = TAFunc.PlusDI(s, e, h, l, c, p, ref beg, ref nb, ref outReal);
+        return (rc, beg, nb, outReal);
+    }
+
+    private static (RetCode, int, int, double[]) MinusDi(int s, int e, double[] h, double[] l, double[] c, int p)
+    {
+        int beg = 0;
+        int nb = 0;
+        double[] outReal = new double[BarCount];
+        RetCode rc = TAFunc.MinusDI(s, e, h, l, c, p, ref beg, ref nb, ref outReal);
+        return (rc, beg, nb, outReal);
+    }
+
+    [Fact]
+    public void OutputNeverClaimsMoreBarsThanTheInputHas()
+    {
+        // Arrange
+        (double[] High, double[] Low, double[] Close) bars = LinearUptrend();
+
+        // Act
+        (RetCode _, int adxBeg, int adxNb, double[] _) = Run(Adx, bars);
+        (RetCode _, int dxBeg, int dxNb, double[] _) = Run(Dx, bars);
+        (RetCode _, int plusBeg, int plusNb, double[] _) = Run(PlusDi, bars);
+        (RetCode _, int minusBeg, int minusNb, double[] _) = Run(MinusDi, bars);
+
+        // Assert
+        // Computing over the whole series, the last described bar is the last bar, so
+        // BegIdx + NBElement is exactly the bar count. The defect reported 102 for all four.
+        (adxBeg + adxNb).ShouldBe(BarCount, "Adx claimed values for bars that do not exist.");
+        (dxBeg + dxNb).ShouldBe(BarCount, "Dx claimed values for bars that do not exist.");
+        (plusBeg + plusNb).ShouldBe(BarCount, "PlusDI claimed values for bars that do not exist.");
+        (minusBeg + minusNb).ShouldBe(BarCount, "MinusDI claimed values for bars that do not exist.");
+    }
+
+    [Fact]
+    public void AdxOnAConstantTrendIsExactlyOneHundredFromItsFirstValue()
+    {
+        // Arrange
+        // DX is a constant 100 on this series, and Wilder's average of a constant is that constant,
+        // so every ADX output is exactly 100 — including the first. Seeding one term short produced
+        // 100 * 13 / 14 = 92.857 and then crept upward without ever arriving.
+        (double[] High, double[] Low, double[] Close) bars = LinearUptrend();
+
+        // Act
+        (RetCode retCode, int begIdx, int nbElement, double[] real) = Run(Adx, bars);
+
+        // Assert
+        retCode.ShouldBe(RetCode.Success);
+        nbElement.ShouldBeGreaterThan(0);
+        (begIdx + nbElement).ShouldBe(BarCount);
+
+        real[0].ShouldBe(100.0, 1e-9, "the ADX seed averaged one value too few");
+
+        // Named separately so the failure message points at the historical value rather than just
+        // reporting a mismatch: 100 * 13 / 14 is what seeding one term short produced.
+        Math.Abs(real[0] - 92.857142857142861).ShouldBeGreaterThan(1e-9);
+
+        for (int k = 0; k < nbElement; k++)
+        {
+            real[k].ShouldBe(100.0, 1e-9, $"ADX drifted at output element {k}.");
+        }
+    }
+
+    [Fact]
+    public void DirectionalIndicatorsSeparateAPureUptrend()
+    {
+        // Arrange
+        (double[] High, double[] Low, double[] Close) bars = LinearUptrend();
+
+        // Act
+        (RetCode plusCode, int _, int plusNb, double[] plus) = Run(PlusDi, bars);
+        (RetCode minusCode, int _, int minusNb, double[] minus) = Run(MinusDi, bars);
+        (RetCode dxCode, int _, int dxNb, double[] dx) = Run(Dx, bars);
+
+        // Assert
+        plusCode.ShouldBe(RetCode.Success);
+        minusCode.ShouldBe(RetCode.Success);
+        dxCode.ShouldBe(RetCode.Success);
+
+        for (int k = 0; k < plusNb; k++)
+        {
+            plus[k].ShouldBe(80.0, 1e-9, $"+DI was not 80 at output element {k}.");
+        }
+
+        for (int k = 0; k < minusNb; k++)
+        {
+            minus[k].ShouldBe(0.0, 1e-9, $"-DI was not 0 at output element {k}.");
+        }
+
+        for (int k = 0; k < dxNb; k++)
+        {
+            dx[k].ShouldBe(100.0, 1e-9, $"DX was not 100 at output element {k}.");
+        }
+    }
+
+    [Fact]
+    public void DirectionalIndicatorsSeparateAPureDowntrend()
+    {
+        // Arrange
+        // The mirror of the uptrend: the roles of +DI and -DI swap and nothing else changes.
+        (double[] High, double[] Low, double[] Close) bars = LinearDowntrend();
+
+        // Act
+        (RetCode _, int _, int plusNb, double[] plus) = Run(PlusDi, bars);
+        (RetCode _, int _, int minusNb, double[] minus) = Run(MinusDi, bars);
+
+        // Assert
+        for (int k = 0; k < plusNb; k++)
+        {
+            plus[k].ShouldBe(0.0, 1e-9, $"+DI was not 0 at output element {k}.");
+        }
+
+        for (int k = 0; k < minusNb; k++)
+        {
+            minus[k].ShouldBe(80.0, 1e-9, $"-DI was not 80 at output element {k}.");
+        }
+    }
+}


### PR DESCRIPTION
Split out of #110 so a semantic change to shipping indicators gets reviewed on its own, with tests, rather than riding inside a fluent-API PR.

`Adx`, `Dx`, `PlusDI` and `MinusDI` seeded one term short — **the same shape as the EMA seed corrected in #105**. The C reference uses `while (i-- > 0)`, which runs its body `i` times; the C# transcription was `while (true) { i--; if (i <= 0) break; }`, which runs it `i - 1` times.

## Two measured symptoms

Both on a 100-bar linear uptrend (`high = 100 + 2i`, `low = 99 + 2i`, `close = 99.5 + 2i`):

**1. The output claimed bars that don't exist.**

| | BegIdx | NBElement | BegIdx+NBElement | bars |
|---|---|---|---|---|
| `Adx` | 27 | 75 → **73** | **102 → 100** | 100 |
| `Dx` | 14 | 88 → **86** | **102 → 100** | 100 |
| `PlusDI` | 14 | 88 → **86** | **102 → 100** | 100 |
| `MinusDI` | 14 | 88 → **86** | **102 → 100** | 100 |

Two values claimed for bars 100 and 101. Any consumer mapping an output element onto a bar — which is the documented contract, and what the samples in #104 do — was misaligned by two, silently.

**2. The ADX seed averaged 13 values while dividing by 14.**

On this series DX is a constant `100`, and Wilder's average of a constant is that constant, so **ADX must be exactly 100 at every bar**. It read `92.857` — which is `100 × 13/14` — then crept toward 100 without arriving:

```
before:  first=92.8571  last=99.9703
after:   first=100      last=100
```

`Adxr` is affected transitively. `+DI`, `-DI` and `DX` **values** were already correct and are unchanged — only their alignment metadata was wrong.

## Tests

The existing `AdxTests`, `DxTests`, `PlusDITests`, `MinusDITests` assert **only `RetCode.Success`**, so none of this was detectable by the suite. The four fixtures here assert numbers, and I verified how each behaves against the old code:

| Fixture | vs. old code |
|---|---|
| `OutputNeverClaimsMoreBarsThanTheInputHas` | **fails** (102 ≠ 100) |
| `AdxOnAConstantTrendIsExactlyOneHundredFromItsFirstValue` | **fails** (92.857 ≠ 100) |
| `DirectionalIndicatorsSeparateAPureUptrend` | passes — **control** |
| `DirectionalIndicatorsSeparateAPureDowntrend` | passes — **control** |

The two controls are deliberate: they pin `+DI = 80`, `-DI = 0`, `DX = 100` (all exact and hand-derivable on a linear trend) to prove the fix leaves the already-correct values alone rather than trading one error for another.

```
without the fix:  Failed: 2, Passed: 2
with the fix:     Failed: 0, Passed: 4
```

## Verification

```
dotnet build TaLibStandard.sln -c Release  ->  0 errors
dotnet test  TaLibStandard.sln -c Release  ->  1129 passed, 0 failed
  Candles 673 · Functions 236 · Backtesting 220
```

## Release note

This changes the numeric output of `Adx`, `Adxr`, `Dx`, `PlusDI` and `MinusDI` in a published package. Callers who compensated for the two-bar misalignment will need to stop. Worth calling out in the v4 notes alongside the ATR/EMA/RSI fixes from #105.

Once this merges, #110 (fluent API) should be rebased on top — it currently carries these same four files, and its strict alignment guard is what surfaced the defect in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)